### PR TITLE
Feat/progress component

### DIFF
--- a/packages/docs/src/components/ui-previews/componentsData.tsx
+++ b/packages/docs/src/components/ui-previews/componentsData.tsx
@@ -286,8 +286,10 @@ export const componentsData: UIComponent[] = [
     label: "PROGRESS",
     component: (
       <>
-        <progress className="progress" max="100" value="70">70%</progress>
+        <progress className="progress progress-orange" max="100" value="70">
+          70%
+        </progress>
       </>
-    )
+    ),
   },
 ];

--- a/packages/neo-metro-city/src/components/progress.css
+++ b/packages/neo-metro-city/src/components/progress.css
@@ -2,11 +2,13 @@
 .progress {
   display: block;
   position: relative;
-  padding: 1px;
-  height: 14px;
+  padding: 4px;
+  height: 16px;
+  min-height: 16px;
   -moz-appearance: none;
   border-radius: 3em;
   border: 1px solid var(--neon-blue);
+  background-color: transparent;
   box-shadow:
     0 0 2px var(--neon-blue),
     0 0 8px var(--neon-blue),
@@ -25,24 +27,65 @@
 
 .progress::-webkit-progress-value {
   /* プログレスバーの進捗部分/-webkit- 用 */
-  background-color: var(--neon-orange);
+  color: var(--neon-blue);
+  background-color: currentColor;
   filter: brightness(1);
   border-radius: 3em;
   box-shadow:
-    0 0 2px var(--neon-orange),
-    0 0 8px var(--neon-orange),
-    inset 0 0 2px var(--neon-orange),
-    inset 0 0 8px var(--neon-orange);
+    0 0 2px currentColor,
+    0 0 4px currentColor,
+    0 0 6px currentColor,
+    0 0 8px currentColor,
+    inset 0 0 2px currentColor,
+    inset 0 0 4px currentColor,
+    inset 0 0 6px currentColor,
+    inset 0 0 8px currentColor;
 }
 
 .progress::-moz-progress-bar {
   /* プログレスバーの進捗部分/-moz- 用 */
-  background-color: var(--neon-orange);
+  color: var(--neon-blue);
+  background-color: currentColor;
   filter: brightness(1);
   border-radius: 3em;
   box-shadow:
-    0 0 2px var(--neon-orange),
-    0 0 8px var(--neon-orange),
-    inset 0 0 2px var(--neon-orange),
-    inset 0 0 8px var(--neon-orange);
+    0 0 2px currentColor,
+    0 0 4px currentColor,
+    0 0 6px currentColor,
+    0 0 8px currentColor,
+    inset 0 0 2px currentColor,
+    inset 0 0 4px currentColor,
+    inset 0 0 6px currentColor,
+    inset 0 0 8px currentColor;
+}
+.progress-orange.progress::-webkit-progress-value {
+  color: var(--neon-orange);
+}
+.progress-orange.progress::-moz-progress-bar {
+  color: var(--neon-orange);
+}
+.progress-pink.progress::-webkit-progress-value {
+  color: var(--neon-pink);
+}
+.progress-pink.progress::-moz-progress-bar {
+  color: var(--neon-pink);
+}
+.progress-purple.progress::-webkit-progress-value {
+  color: var(--neon-purple);
+}
+.progress-purple.progress::-moz-progress-bar {
+  color: var(--neon-purple);
+}
+.progress-green.progress::-webkit-progress-value {
+  color: var(--neon-green);
+}
+.progress-green.progress::-moz-progress-bar {
+  color: var(--neon-green);
+}
+.progress-yellow.progress::-webkit-progress-value {
+  color: var(--neon-yellow);
+}
+
+.progress-yellow.progress::-moz-progress-bar {
+  color: var(--neon-yellow);
 }


### PR DESCRIPTION
close #14 

## 概要

- progressコンポーネントの実装
- HTMLのprogress要素を使用
- デフォルトから `width`, `height`, `padding` をカスタマイズ可能

## 使用例

```html
<!-- デフォルト（progressクラスのみ） -->
  <progress className="progress" max="100" value="50">30%</progress>
<!-- width, heightをカスタマイズ -->
  <progress className="progress w-xl h-6" max="100" value="50">50%</progress>
<!-- width, height, paddingをカスタマイズ -->
  <progress className="progress w-2xl h-12 p-1" max="100" value="60">60%</progress>
```