### PR TITLE
feat: add badge docs size and colors

### DIFF
--- a/packages/docs/src/ui-previews/badgePreviewData.tsx
+++ b/packages/docs/src/ui-previews/badgePreviewData.tsx
@@ -9,14 +9,14 @@ const badgePreviewData: ComponentPreviewData = {
     {
       title: "Badge",
       component: <span className="badge">BADGE</span>,
-      htmlStr: dedent(`<span className="badge">BADGE</span>`),
+      htmlStr: dedent(`<span class="badge">BADGE</span>`),
       jsxStr: dedent(`<span className="badge">BADGE</span>`),
     },
     {
       title: "Badge sizes",
       component: (
         <div className="flex flex-wrap gap-4 justify-center items-center">
-          <span className="badge text-xs">Xsmall</span>
+          <span className="badge text-xs">XSmall</span>
           <span className="badge text-sm">Small</span>
           <span className="badge text-base">Medium</span>
           <span className="badge text-lg">Large</span>
@@ -24,16 +24,16 @@ const badgePreviewData: ComponentPreviewData = {
         </div>
       ),
       htmlStr: dedent(`
-        <div className="flex flex-wrap gap-4 justify-center items-center">
-          <span className="badge text-xs">Xsmall</span>
-          <span className="badge text-sm">Small</span>
-          <span className="badge text-base">Medium</span>
-          <span className="badge text-lg">Large</span>
-          <span className="badge text-xl">XLarge</span>
+        <div class="flex flex-wrap gap-4 justify-center items-center">
+          <span class="badge text-xs">XSmall</span>
+          <span class="badge text-sm">Small</span>
+          <span class="badge text-base">Medium</span>
+          <span class="badge text-lg">Large</span>
+          <span class="badge text-xl">XLarge</span>
         </div>`),
       jsxStr: dedent(`
         <div className="flex flex-wrap gap-4 justify-center items-center">
-          <span className="badge text-xs">Xsmall</span>
+          <span className="badge text-xs">XSmall</span>
           <span className="badge text-sm">Small</span>
           <span className="badge text-base">Medium</span>
           <span className="badge text-lg">Large</span>
@@ -53,13 +53,13 @@ const badgePreviewData: ComponentPreviewData = {
         </div>
       ),
       htmlStr: dedent(`
-        <div className="flex flex-wrap gap-4">
-          <span className="badge">NEUTRAL</span>
-          <span className="badge badge-orange">ORANGE</span>
-          <span className="badge badge-pink">PINK</span>
-          <span className="badge badge-green">GREEN</span>
-          <span className="badge badge-red">RED</span>
-          <span className="badge badge-yellow">YELLOW</span>
+        <div class="flex flex-wrap gap-4">
+          <span class="badge">NEUTRAL</span>
+          <span class="badge badge-orange">ORANGE</span>
+          <span class="badge badge-pink">PINK</span>
+          <span class="badge badge-green">GREEN</span>
+          <span class="badge badge-red">RED</span>
+          <span class="badge badge-yellow">YELLOW</span>
         </div>`),
       jsxStr: dedent(`
         <div className="flex flex-wrap gap-4">

--- a/packages/docs/src/ui-previews/badgePreviewData.tsx
+++ b/packages/docs/src/ui-previews/badgePreviewData.tsx
@@ -9,16 +9,8 @@ const badgePreviewData: ComponentPreviewData = {
     {
       title: "Badge",
       component: <span className="badge">BADGE</span>,
-      htmlStr: dedent(
-        `<textarea class="textarea" placeholder="Enter your encrypted message..."></textarea>`
-      ),
-      jsxStr: dedent(
-        `<div className="loading">
-          <span className="dot"></span>
-          <span className="dot"></span>
-          <span className="dot"></span>
-        </div>`
-      ),
+      htmlStr: dedent(`<span className="badge">BADGE</span>`),
+      jsxStr: dedent(`<span className="badge">BADGE</span>`),
     },
   ],
 };

--- a/packages/docs/src/ui-previews/badgePreviewData.tsx
+++ b/packages/docs/src/ui-previews/badgePreviewData.tsx
@@ -13,6 +13,34 @@ const badgePreviewData: ComponentPreviewData = {
       jsxStr: dedent(`<span className="badge">BADGE</span>`),
     },
     {
+      title: "Badge sizes",
+      component: (
+        <div className="flex flex-wrap gap-4 justify-center items-center">
+          <span className="badge text-xs">Xsmall</span>
+          <span className="badge text-sm">Small</span>
+          <span className="badge text-base">Medium</span>
+          <span className="badge text-lg">Large</span>
+          <span className="badge text-xl">XLarge</span>
+        </div>
+      ),
+      htmlStr: dedent(`
+        <div className="flex flex-wrap gap-4 justify-center items-center">
+          <span className="badge text-xs">Xsmall</span>
+          <span className="badge text-sm">Small</span>
+          <span className="badge text-base">Medium</span>
+          <span className="badge text-lg">Large</span>
+          <span className="badge text-xl">XLarge</span>
+        </div>`),
+      jsxStr: dedent(`
+        <div className="flex flex-wrap gap-4 justify-center items-center">
+          <span className="badge text-xs">Xsmall</span>
+          <span className="badge text-sm">Small</span>
+          <span className="badge text-base">Medium</span>
+          <span className="badge text-lg">Large</span>
+          <span className="badge text-xl">XLarge</span>
+        </div>`),
+    },
+    {
       title: "Badge colors",
       component: (
         <div className="flex flex-wrap gap-4">

--- a/packages/docs/src/ui-previews/badgePreviewData.tsx
+++ b/packages/docs/src/ui-previews/badgePreviewData.tsx
@@ -12,6 +12,37 @@ const badgePreviewData: ComponentPreviewData = {
       htmlStr: dedent(`<span className="badge">BADGE</span>`),
       jsxStr: dedent(`<span className="badge">BADGE</span>`),
     },
+    {
+      title: "Badge colors",
+      component: (
+        <div className="flex flex-wrap gap-4">
+          <span className="badge">NEUTRAL</span>
+          <span className="badge badge-orange">ORANGE</span>
+          <span className="badge badge-pink">PINK</span>
+          <span className="badge badge-green">GREEN</span>
+          <span className="badge badge-red">RED</span>
+          <span className="badge badge-yellow">YELLOW</span>
+        </div>
+      ),
+      htmlStr: dedent(`
+        <div className="flex flex-wrap gap-4">
+          <span className="badge">NEUTRAL</span>
+          <span className="badge badge-orange">ORANGE</span>
+          <span className="badge badge-pink">PINK</span>
+          <span className="badge badge-green">GREEN</span>
+          <span className="badge badge-red">RED</span>
+          <span className="badge badge-yellow">YELLOW</span>
+        </div>`),
+      jsxStr: dedent(`
+        <div className="flex flex-wrap gap-4">
+          <span className="badge">NEUTRAL</span>
+          <span className="badge badge-orange">ORANGE</span>
+          <span className="badge badge-pink">PINK</span>
+          <span className="badge badge-green">GREEN</span>
+          <span className="badge badge-red">RED</span>
+          <span className="badge badge-yellow">YELLOW</span>
+        </div>`),
+    },
   ],
 };
 


### PR DESCRIPTION
## 実装内容
バッジのHTMLとJSXのサンプルコードの内容を修正しました。
また、サイズとカラーバリエーションも表示させました。
ご確認よろしくお願いいたします

### バッジのHTMLとJSXのサンプルコードの修正

| 修正前 | 修正後 |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/5c853cd7-7ca4-406d-b421-46586bcd0c3e" width="400px" /> | <img src="https://github.com/user-attachments/assets/700ce2e6-f23a-4d7c-9edb-70d2a75eafc9" width="400px" /> |
| <img src="https://github.com/user-attachments/assets/e10db819-4919-49da-8f9e-7160e19a11a7" width="400px" /> | <img src="https://github.com/user-attachments/assets/2c509b38-74cb-408c-9517-f03df0b74472" width="400px" /> |

### サイズとカラーバリエーションの表示追加

![image](https://github.com/user-attachments/assets/29117855-590e-4f30-93c7-3de2a58dffe4)
