### PR TITLE
fix: purple button color

### DIFF
--- a/packages/neo-metro-city/src/components/button.css
+++ b/packages/neo-metro-city/src/components/button.css
@@ -33,7 +33,7 @@
   color: var(--neon-green);
 }
 .btn.btn-purple {
-  color: var(--neon-pink);
+  color: var(--neon-purple);
 }
 .btn.btn-yellow {
   color: var(--neon-yellow);


### PR DESCRIPTION
## 実装内容
`.btn.btn-purple`クラスのcolorプロパティが`--neon-pink`を参照していた箇所を修正しました。
ご確認よろしくお願いいたします。

| Before | After |
| ----- | ----- |
| <img width="920" alt="スクリーンショット 2025-06-11 23 50 07" src="https://github.com/user-attachments/assets/2e6abe98-55ca-4328-b197-ddbeb9261931" /> | <img width="917" alt="スクリーンショット 2025-06-11 23 51 12" src="https://github.com/user-attachments/assets/6b0a119a-6901-4f62-83c9-6230fecc91bf" /> |
